### PR TITLE
Pass all compile arguments through to proxied compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 BUILD_DIR=${1}
-CACHE_DIR=${2}
 EMBEDDED_BP_DIR=${BUILD_DIR}/.buildpack
 
-exec ${EMBEDDED_BP_DIR}/bin/compile ${BUILD_DIR} ${CACHE_DIR}
+exec ${EMBEDDED_BP_DIR}/bin/compile "$@"


### PR DESCRIPTION
Heroku now passes a third argument to the compile script. Rather than adding that argument explicitly, it seemed better to pass the entire argument list so this won't need to be updated again if they add a fourth one at some point.
